### PR TITLE
feat: B2B partner dashboard and theater registration

### DIFF
--- a/src/main/java/com/example/mdb/controller/BookingController.java
+++ b/src/main/java/com/example/mdb/controller/BookingController.java
@@ -25,7 +25,7 @@ public class BookingController {
     private final RestResponseBuilder responseBuilder;
 
     @PostMapping
-    @PreAuthorize("hasAuthority('USER')")
+    @PreAuthorize("hasAnyAuthority('USER', 'THEATER_OWNER')")
     public ResponseEntity<ResponseStructure<BookingResponse>> createBooking(
             @Valid @RequestBody BookingRequest bookingRequest,
             Authentication auth) {
@@ -36,7 +36,7 @@ public class BookingController {
     }
 
     @PatchMapping("/{bookingId}/cancel")
-    @PreAuthorize("hasAuthority('USER')")
+    @PreAuthorize("hasAnyAuthority('USER', 'THEATER_OWNER')")
     public ResponseEntity<ResponseStructure<BookingResponse>> cancelBooking(
             @PathVariable String bookingId,
             Authentication auth) {
@@ -47,7 +47,7 @@ public class BookingController {
     }
 
     @PostMapping("/{bookingId}/resend-ticket")
-    @PreAuthorize("hasAuthority('USER')")
+    @PreAuthorize("hasAnyAuthority('USER', 'THEATER_OWNER')")
     public ResponseEntity<ResponseStructure<String>> resendTicket(
             @PathVariable String bookingId,
             Authentication auth) {
@@ -56,7 +56,7 @@ public class BookingController {
     }
 
     @GetMapping("/my-bookings")
-    @PreAuthorize("hasAuthority('USER')")
+    @PreAuthorize("hasAnyAuthority('USER', 'THEATER_OWNER')")
     public ResponseEntity<ResponseStructure<List<BookingResponse>>> getMyBookings(Authentication auth) {
         String email = auth.getName();
         List<BookingResponse> responses = bookingService.getMyBookings(email);

--- a/src/main/java/com/example/mdb/controller/TheaterController.java
+++ b/src/main/java/com/example/mdb/controller/TheaterController.java
@@ -13,9 +13,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @AllArgsConstructor
 @RestController
 @RequestMapping("/theaters")
+@CrossOrigin(origins = "*")
 public class TheaterController {
 
     private final TheaterService theaterService;
@@ -40,5 +43,12 @@ public class TheaterController {
     public ResponseEntity<ResponseStructure<TheaterResponse>> updateTheater(@PathVariable String theaterId, @Valid @RequestBody TheaterRequest theaterRequest){
         TheaterResponse theaterResponse = theaterService.updateTheater(theaterId, theaterRequest);
         return responseBuilder.success(HttpStatus.OK, "Theater updated successfully", theaterResponse);
+    }
+
+    @GetMapping("/my-theaters")
+    @PreAuthorize("hasAuthority('THEATER_OWNER')")
+    public ResponseEntity<ResponseStructure<List<TheaterResponse>>> getMyTheaters(Authentication auth) {
+        List<TheaterResponse> responses = theaterService.getMyTheaters(auth.getName());
+        return responseBuilder.success(HttpStatus.OK, "Owner properties retrieved successfully", responses);
     }
 }

--- a/src/main/java/com/example/mdb/repository/TheaterRepository.java
+++ b/src/main/java/com/example/mdb/repository/TheaterRepository.java
@@ -3,7 +3,11 @@ package com.example.mdb.repository;
 import com.example.mdb.entity.Theater;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TheaterRepository extends JpaRepository<Theater, String> {
 
     boolean existsByNameAndAddressAndCity(String name, String address, String city);
+
+    List<Theater> findByTheaterOwner_Email(String email);
 }

--- a/src/main/java/com/example/mdb/service/TheaterService.java
+++ b/src/main/java/com/example/mdb/service/TheaterService.java
@@ -4,6 +4,8 @@ import com.example.mdb.dto.TheaterRequest;
 import com.example.mdb.dto.TheaterResponse;
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 public interface TheaterService {
 
 
@@ -12,4 +14,6 @@ public interface TheaterService {
     TheaterResponse findTheater(String theaterId);
 
     TheaterResponse updateTheater(String theaterId, @Valid TheaterRequest theaterRequest);
+
+    List<TheaterResponse> getMyTheaters(String name);
 }

--- a/src/main/java/com/example/mdb/service/impl/TheaterServiceImpl.java
+++ b/src/main/java/com/example/mdb/service/impl/TheaterServiceImpl.java
@@ -14,6 +14,9 @@ import com.example.mdb.service.TheaterService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @AllArgsConstructor
 public class TheaterServiceImpl implements TheaterService {
@@ -58,5 +61,13 @@ public class TheaterServiceImpl implements TheaterService {
 
         theater = theaterRepository.save(theater);
         return theaterMapper.theaterResponseMapper(theater);
+    }
+
+    @Override
+    public List<TheaterResponse> getMyTheaters(String email) {
+        List<Theater> myTheaters = theaterRepository.findByTheaterOwner_Email(email);
+        return myTheaters.stream()
+                .map(theaterMapper::theaterResponseMapper)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Overview: Integrates the B2B Partner Dashboard, enabling theater owners to register and manage their properties via the frontend UI. 

##Changes Made:
1. Backend:

- Added `findByTheaterOwner_Email` in `TheaterRepository` and exposed `GET /theaters/my-theaters` endpoint.
- Resolved CORS policy block in `TheaterController`.
- Fixed 403 Unauthorized bug in `BookingController` by granting `THEATER_OWNER` authority access.

2. Frontend:

- Built `AddTheaterModal` component for new property registration.
- Updated `OwnerDashboard` to fetch and render the owner's active properties.

## Testing Steps:
1. Authenticate with a `THEATER_OWNER` account.
2. Navigate to Partner Dashboard.
3. Add a new property via the modal UI.
4. Verify the newly created property populates in the "My Properties" grid.
5. Verify duplicate property registration correctly rejects the payload and shows validation error.